### PR TITLE
Use dateutil.parser.parse to parse datetime of input dataset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 lxml
 pytz
+dateutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 lxml
 pytz
-dateutil
+python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 lxml
 pytz
-dateutils
+dateutil


### PR DESCRIPTION
Previously if date tag  was not formatted strictly '%Y-%m-%dT%H:%M:%SZ' the crawler was failing.  dateutil.parser.parse is more robust. Besides exception is caught and a warning is given if the date tag acnnot be parsed.